### PR TITLE
Update the Slack invite link (new one is valid for 4 weeks from now

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -65,7 +65,7 @@
             <div class="row text-center">
               <!-- slack -->
               <div class="col-6 col-md-3">
-                <a href="https://join.slack.com/t/bitcoincashnode/shared_invite/enQtOTYyMjIwOTEyODcwLTIwYzg4YTQ1OGYwNjE0ZmFmNGVhNDkwMzgwZjMzMzg4MmM5YzQ1ZGJhOWY4ZmI1MzYzODdiODM0Yjc3YjY4N2I" target="_blank">
+                <a href="https://join.slack.com/t/bitcoincashnode/shared_invite/zt-ctozdnpv-pUknwZpANybRg5xyeKyx8Q" target="_blank">
                   <img src="/static/img/icons/slack.svg" height="30" alt="Slack">
                   <p class="mt-3 text-muted">Slack</p>
                 </a>


### PR DESCRIPTION
Slack shows a new invite link, valid for 4 weeks.

This patch updates the site to use the new link.