### PR TITLE
Update Ubuntu PPA download and deployment instructions

### DIFF
--- a/app/download/ubuntu.html
+++ b/app/download/ubuntu.html
@@ -36,7 +36,7 @@
         <div class="row justify-content-center">
           <div class="col-11 col-lg-8 col-xl-7">
             <h2 class="py-4">Install Bitcoin Cash Node</h2>
-            <p><b>If on Ubuntu 16.04 xenial</b>, you need to do some extra steps:</p>
+            <p><b>If on Ubuntu 16.04 xenial or 18.04 bionic</b>, you need to do some extra steps:</p>
             <div class="jumbotron">
               <code>
                 sudo add-apt-repository ppa:ubuntu-toolchain-r/test <br>


### PR DESCRIPTION
Since 20.04 has been released we need to apply the same
workaround used for 16.04 also to bionic 18.04.