### PR TITLE
Update banner to link to Bitcoin Cash (BCH) November 2020 Upgrade statement

### DIFF
--- a/app/templates/base.njk
+++ b/app/templates/base.njk
@@ -40,7 +40,7 @@
   <div class="bg-dark pb-1">
     <div class="bg-info py-2">
       <div class="container text-center">
-        <a class="text-white" href="/$( _lang_ )$/newsroom/bchn-flipstarted">We thank everyone who helped us reach 100% of our crowd-funding on Flipstarter.cash!</a>
+        <a class="text-white" href="https://read.cash/@sha256_88ebd526/bitcoin-cash-bch-november-2020-upgrade-statement-f7c03159">BCHN supports the Bitcoin Cash (BCH) November 2020 Upgrade statement</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
New banner text:

`BCHN supports the Bitcoin Cash (BCH) November 2020 Upgrade statement`

This links to the Upgrade statement:

https://read.cash/@sha256_88ebd526/bitcoin-cash-bch-november-2020-upgrade-statement-f7c03159