### PR TITLE
Add BCH Upgrade 2022 statement (EN)

### DIFF
--- a/app/data/newsroom.json
+++ b/app/data/newsroom.json
@@ -17,6 +17,14 @@
       "tags": ["announcement"]
     },
     {
+      "title": "Bitcoin Cash Upgrade 2022",
+      "date": "November 15 2021",
+      "author": "Bitcoin Cash Node Team",
+      "img": "/static/thumbnail.png",
+      "filename": "Bitcoin-Cash-Upgrade-2022-Statement",
+      "tags": ["announcement"]
+    },
+    {
       "title": "BCHN Technical Bulletin 2021-10-31 (LMDB Preliminary Technical Report)",
       "date": "31 October 2021",
       "author": "matricz",

--- a/app/newsroom/Bitcoin-Cash-Upgrade-2022-Statement.html
+++ b/app/newsroom/Bitcoin-Cash-Upgrade-2022-Statement.html
@@ -1,0 +1,70 @@
+{% extends 'base.njk' %}{% block title %}Bitcoin Cash Upgrade 2022{% endblock %}{% block description %}{% endblock %}{% block body %}
+<section class="bg-dark">
+    <div class="container">
+        <div class="row pb-3">
+            <div class="col my-5 py-5 text-center">
+                <h1 class="text-white">Bitcoin Cash Upgrade 2022</h1> 
+            </div>
+        </div>
+    </div>
+</section>
+<section class="bg-light">
+    <div class="container py-6">
+        <div class="row justify-content-center">
+            <article class="col-md-10 col-lg-8">
+                <div class="d-flex align-items-center pb-5">
+                    <img src="/static/img/logomark.svg" alt="Logo" class="mr-3 w-auto" height="40">
+                    <div>
+                        <div>by <strong>Bitcoin Cash Node Team</strong>
+                        </div>
+                        <div class="text-small text-muted">15 November 2021</div>
+                    </div>
+                </div>
+                <div class="content">
+                    <p>
+
+                    </p>
+                    <h3 id="bitcoin-cash-upgrade-2022">Bitcoin Cash Upgrade 2022</h3>
+                    <p>On May 15th, 2022, Bitcoin Cash will undergo a technical upgrade to further expand its virtual machine (VM) contracting capabilities. The upgrade will enable a variety of new financial products and services by:</p>
+                    <ol>
+                        <li>
+                            <p>Supporting arithmetic operations on significantly larger numbers. An expanded arithmetic range will allow contracts to manage very large balances with full precision, enabling contract-based treasuries and improving the efficiency
+                                of existing contract designs.</p>
+                        </li>
+                        <li>
+                            <p>Adding new operations, including native introspection operations. These new operations will enable the development of far more secure wallets, efficient recurring payments, and more.</p>
+                        </li>
+                    </ol>
+                    <p>This upgrade has been discussed, developed and reviewed by a large consortium of companies, development teams, and independent developers - including all existing node software teams. As of November 15, 2021, deliberation has concluded
+                        without contest, and the upgrade will activate on May 15, 2022 without a network split.</p>
+                    <p>The Bitcoin Cash Node (BCHN) software will include support for the 2022 Bitcoin Cash upgrade in its upcoming release v24.0.0.</p>
+                    <h4 id="upgrade-schedule">Upgrade Schedule</h4>
+                    <ul>
+                        <li>Sep 15, 2021 - The upgrade was activated on a public test network.</li>
+                        <li>Nov 15, 2021 - BCHN commits to upgrade scope and a November release of v24.0.0</li>
+                        <li>Feb 15, 2022 - All ecosystem software is expected to have a stable release supporting the upgrade.</li>
+                        <li>May 15, 2022 - Upgrade is activated on the main network.</li>
+                    </ul>
+                    <h4 id="upgrade-preparation">Upgrade Preparation</h4>
+                    <p>For Bitcoin Cash users, this upgrade requires no preparation; payments can safely be made and accepted throughout activation. Existing wallet software will continue to function without upgrades.</p>
+                    <p>Miners, exchanges and other node operators are advised to upgrade node software before May 15, 2022 to avoid service disruptions. The upgrade requires no downtime, and operations can proceed normally.</p>
+                    <h4 id="technical-details">Technical Details</h4>
+                    <p>The May 15, 2022 upgrade includes the following consensus changes:</p>
+                    <ul>
+                        <li><a href="https://gitlab.com/GeneralProtocols/research/chips/-/blob/master/CHIP-2021-02-Bigger-Script-Integers.md">CHIP-2021-03: Bigger Script Integers</a>
+                            <a href="https://bitcoincashresearch.org/t/chip-2021-03-bigger-script-integers/39">(Discussion)</a>
+                        </li>
+                        <li><a href="https://gitlab.com/GeneralProtocols/research/chips/-/blob/master/CHIP-2021-02-Add-Native-Introspection-Opcodes.md">CHIP-2021-02: Native Introspection Opcodes</a>
+                            <a href="https://bitcoincashresearch.org/t/chip-2021-02-add-native-introspection-opcodes/307">(Discussion)</a>
+                        </li>
+                    </ul>
+                    <p>For more BCHN-related information about the May 15, 2021 network upgrade, please visit</p>
+                    <p> <a href="https://upgradespecs.bitcoincashnode.org/2022-05-15-upgrade/"><a href="https://upgradespecs.bitcoincashnode.org/2022-05-15-upgrade/">https://upgradespecs.bitcoincashnode.org/2022-05-15-upgrade/</a></a>
+                    </p>
+                    <p>Sincerely,</p>
+                    <p>The Bitcoin Cash Node team.</p>
+                </div>
+            </article>
+        </div>
+    </div>
+</section>{% endblock %}

--- a/blog/Bitcoin-Cash-Upgrade-2022-Statement.md
+++ b/blog/Bitcoin-Cash-Upgrade-2022-Statement.md
@@ -1,0 +1,70 @@
+---
+layout: layout.html
+---
+
+<% set('title', 'Bitcoin Cash Upgrade 2022') %>
+<% set('date', '15 November 2021') %>
+<% set('author', 'Bitcoin Cash Node Team') %>
+
+### Bitcoin Cash Upgrade 2022
+
+On May 15th, 2022, Bitcoin Cash will undergo a technical upgrade to further
+expand its virtual machine (VM) contracting capabilities.
+The upgrade will enable a variety of new financial products and services by:
+
+1. Supporting arithmetic operations on significantly larger numbers.
+   An expanded arithmetic range will allow contracts to manage very large
+   balances with full precision, enabling contract-based treasuries and
+   improving the efficiency of existing contract designs.
+
+2. Adding new operations, including native introspection operations. These
+   new operations will enable the development of far more secure wallets,
+   efficient recurring payments, and more.
+
+This upgrade has been discussed, developed and reviewed by a large
+consortium of companies, development teams, and independent developers -
+including all existing node software teams. As of November 15, 2021,
+deliberation has concluded without contest, and the upgrade will activate
+on May 15, 2022 without a network split.
+
+The Bitcoin Cash Node (BCHN) software will include support for the 2022
+Bitcoin Cash upgrade in its upcoming release v24.0.0.
+
+
+#### Upgrade Schedule
+
+* Sep 15, 2021 - The upgrade was activated on a public test network.
+* Nov 15, 2021 - BCHN commits to upgrade scope and a November release of v24.0.0
+* Feb 15, 2022 - All ecosystem software is expected to have a stable
+  release supporting the upgrade.
+* May 15, 2022 - Upgrade is activated on the main network.
+
+
+#### Upgrade Preparation
+
+For Bitcoin Cash users, this upgrade requires no preparation; payments
+can safely be made and accepted throughout activation. Existing wallet
+software will continue to function without upgrades.
+
+Miners, exchanges and other node operators are advised to upgrade node
+software before May 15, 2022 to avoid service disruptions. The upgrade
+requires no downtime, and operations can proceed normally.
+
+
+#### Technical Details
+
+The May 15, 2022 upgrade includes the following consensus changes:
+
+- [CHIP-2021-03: Bigger Script Integers](https://gitlab.com/GeneralProtocols/research/chips/-/blob/master/CHIP-2021-02-Bigger-Script-Integers.md)
+  [(Discussion)](https://bitcoincashresearch.org/t/chip-2021-03-bigger-script-integers/39)
+- [CHIP-2021-02: Native Introspection Opcodes](https://gitlab.com/GeneralProtocols/research/chips/-/blob/master/CHIP-2021-02-Add-Native-Introspection-Opcodes.md)
+  [(Discussion)](https://bitcoincashresearch.org/t/chip-2021-02-add-native-introspection-opcodes/307)
+
+For more BCHN-related information about the May 15, 2021 network upgrade,
+please visit
+
+  [https://upgradespecs.bitcoincashnode.org/2022-05-15-upgrade/](https://upgradespecs.bitcoincashnode.org/2022-05-15-upgrade/)
+
+Sincerely,
+
+The Bitcoin Cash Node team.


### PR DESCRIPTION
Backfilling the announcement we published first via 

  https://read.cash/@bitcoincashnode/bitcoin-cash-upgrade-2022-ea72ab86